### PR TITLE
Fix Win32 compilation issue in Sys_StatFile

### DIFF
--- a/code/sys/sys_win32.c
+++ b/code/sys/sys_win32.c
@@ -352,11 +352,11 @@ returns 0 otherwise
 ==============
 */
 int Sys_StatFile( char *ospath ) {
-	struct _stat stat;
-	if ( _stat( ospath, &stat ) == -1 ) {
+	struct _stat st;
+	if ( _stat( ospath, &st ) == -1 ) {
 		return -1;
 	}
-	if ( stat.st_mode & _S_IFDIR ) {
+	if ( st.st_mode & _S_IFDIR ) {
 		return 1;
 	}
 	return 0;


### PR DESCRIPTION
I wasn't able to compile spearmint under Windows 7 with MinGW32.
There was a conflict between the `stat` function and the `stat` variable name.

Choosing another name for the variable fixes this.
