### PR TITLE
Fix compiling renderergl2's GLSL shaders as C files under Cygwin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1152,7 +1152,7 @@ define DO_REF_STR
 $(echo_cmd) "REF_STR $<"
 $(Q)rm -f $@
 $(Q)echo "const char *fallbackShader_$(notdir $(basename $<)) =" >> $@
-$(Q)cat $< | sed 's/^/\"/;s/$$/\\n\"/' >> $@
+$(Q)cat $< | sed -e 's/^/\"/;s/$$/\\n\"/' -e 's/\r//g' >> $@
 $(Q)echo ";" >> $@
 endef
 


### PR DESCRIPTION
Now the `sed` command copes with files using Windows-style line endings.
