### PR TITLE
spearmint: Always keep bots, even with 'devmap'

### DIFF
--- a/code/server/sv_ccmds.c
+++ b/code/server/sv_ccmds.c
@@ -182,16 +182,15 @@ static void SV_Map_f( void ) {
 	cmd = Cmd_Argv(0);
 	if ( !Q_stricmp( cmd, "devmap" ) ) {
 		cheat = qtrue;
-		killBots = qtrue;
 	} else {
 		cheat = qfalse;
-		killBots = Com_GameIsSinglePlayer();
 	}
 
 	// save the map name here cause on a map restart we reload the q3config.cfg
 	// and thus nuke the arguments of the map command
 	Q_strncpyz(mapname, map, sizeof(mapname));
 
+	killBots = Com_GameIsSinglePlayer();
 	// start up the map
 	SV_SpawnServer( mapname, killBots );
 

--- a/code/server/sv_ccmds.c
+++ b/code/server/sv_ccmds.c
@@ -191,6 +191,7 @@ static void SV_Map_f( void ) {
 	Q_strncpyz(mapname, map, sizeof(mapname));
 
 	killBots = Com_GameIsSinglePlayer();
+
 	// start up the map
 	SV_SpawnServer( mapname, killBots );
 


### PR DESCRIPTION
# Keep bots even if a new map is started in developer mode.
Currently bots will be automatically kicked from server if a new map is loading, when the map was called via \devmap command.
If a map is called via regular \map command, the bots will not get kicked.
For (bot) development purposes it would be very comfortable if the bots will also move on to a new map even in developer mode. Especially because a few bot related cvars are only changeable if cheats are enabled (which is absurd when the bots are kicked to make use of these cvars.)
It's very frustrating if someone adds 64 bots, starts a map with a \devmap command and has to manually add 64 bots again.
## ***What is changing:***
  + In multiplayer games bots will no longer get kicked from server if a new map is started via \devmap command.
## ***Notes:***
  + The default 'Singleplayer' behaviour remains the same (bots will be kicked anyways).
  + Bots can still easily kicked, via \kickbots command.
  + Tested with baseq3 and Team Arena mod.
  + I have to admit, this is really a 'quality of life' feature for developers, not a bugfix.